### PR TITLE
Problem: acn-sdk-c submodule fails to download if git user does not have ssh keys registered

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "acn-sdk-c"]
 	path = acn-sdk-c
-	url = git@github.com:arrow-acs/acn-sdk-c.git
+	url = https://github.com/arrow-acs/acn-sdk-c.git


### PR DESCRIPTION
After cloning the repo on an environment where no SSH keys are registered in github, doing: 

    git submodule init
    git submodule update

fails to clone the submodule (no ssh access rights).

Solution: change the URL of the submodule repository to the https endpoint